### PR TITLE
Modernized Travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: elixir
 matrix:
   include:
-    - otp_release: 18.3
-      elixir: 1.3.2
-    - otp_release: 19.0
-      elixir: 1.3.2
+    - otp_release: 24.3
+      elixir: 1.14.5
+    - otp_release: 25.3
+      elixir: 1.15.7
 sudo: false
+dist: focal
 before_script:
-  - mix local.hex --force # Update Mix
+  - mix local.hex --force
+  - mix local.rebar --force
   - mix deps.get --only test
 script:
   - mix test
+cache:
+  directories:
+    - deps
+    - _build


### PR DESCRIPTION
Updated the Elixir and OTP versions:

Changed from `1.3.2` to 1`.14.5` and `1.15.7` (latest stable versions) Changed from OTP `18.3` and `19.0` to `24.3` and `25.3` (recent stable versions).

Added `dist: focal` to use Ubuntu 20.04 (Focal Fossa) as the build environment.

Added `mix local.rebar --force` to ensure Rebar is installed.

I just figure if you use Travis CI (or re-up this project again which I really like, this may come in handy!).